### PR TITLE
Remove unused semver dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -513,12 +513,6 @@
       "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
       "dev": true
     },
-    "@types/semver": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
-      "integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
-      "dev": true
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -4484,7 +4478,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,11 @@
   "dependencies": {
     "@actions/core": "^1.0.0",
     "axios": "^0.19.0",
-    "jsonwebtoken": "^8.5.1",
-    "semver": "^6.1.1"
+    "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
     "@types/jest": "^24.0.17",
     "@types/node": "^12.7.2",
-    "@types/semver": "^6.0.0",
     "@vercel/ncc": "^0.24.1",
     "jest": "^24.8.0",
     "jest-circus": "^24.7.1",


### PR DESCRIPTION
This dependency is not used in the source file, so it can be removed from `package.json`.